### PR TITLE
Some cleanups

### DIFF
--- a/embedding/csharp/Tizen.Flutter.Embedding/NUIFlutterView.cs
+++ b/embedding/csharp/Tizen.Flutter.Embedding/NUIFlutterView.cs
@@ -102,24 +102,24 @@ namespace Tizen.Flutter.Embedding
             }
 
             Focusable = true;
-            KeyEvent += (object source, KeyEventArgs eventArgs) =>
+            KeyEvent += (object s, KeyEventArgs e) =>
             {
                 FlutterDesktopViewOnKeyEvent(
-                    View, eventArgs.Key.KeyPressedName, eventArgs.Key.KeyPressed, (uint)eventArgs.Key.KeyModifier,
-                    (uint)eventArgs.Key.KeyCode, eventArgs.Key.State == Key.StateType.Down);
+                    View, e.Key.KeyPressedName, e.Key.KeyPressed, (uint)e.Key.KeyModifier, (uint)e.Key.KeyCode,
+                    e.Key.State == Key.StateType.Down);
                 return true;
             };
 
-            TouchEvent += (object source, TouchEventArgs eventArgs) =>
+            TouchEvent += (object s, TouchEventArgs e) =>
             {
-                if (_lastTouchEventTime == eventArgs.Touch.GetTime())
+                if (_lastTouchEventTime == e.Touch.GetTime())
                 {
                     return false;
                 }
                 FocusManager.Instance.SetCurrentFocusView(this);
 
                 FlutterDesktopViewMouseEventType type;
-                switch (eventArgs.Touch.GetState(0))
+                switch (e.Touch.GetState(0))
                 {
                     case PointStateType.Down:
                     default:
@@ -133,10 +133,10 @@ namespace Tizen.Flutter.Embedding
                         break;
                 }
                 FlutterDesktopViewOnMouseEvent(
-                    View, type, eventArgs.Touch.GetLocalPosition(0).X, eventArgs.Touch.GetLocalPosition(0).Y,
-                    eventArgs.Touch.GetTime(), eventArgs.Touch.GetDeviceId(0));
+                    View, type, e.Touch.GetLocalPosition(0).X, e.Touch.GetLocalPosition(0).Y, e.Touch.GetTime(),
+                    e.Touch.GetDeviceId(0));
 
-                _lastTouchEventTime = eventArgs.Touch.GetTime();
+                _lastTouchEventTime = e.Touch.GetTime();
                 return true;
             };
 

--- a/embedding/csharp/Tizen.Flutter.Embedding/Tizen.Flutter.Embedding.csproj
+++ b/embedding/csharp/Tizen.Flutter.Embedding/Tizen.Flutter.Embedding.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup Condition="$(TizenApiVersion) &lt; 6.5">
     <PackageReference Include="Tizen.NET" Version="4.0.1.14164" />
+    <Compile Remove="NUIFlutterView.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TizenApiVersion) &gt;= 6.5">

--- a/lib/build_targets/plugins.dart
+++ b/lib/build_targets/plugins.dart
@@ -89,8 +89,14 @@ class NativePlugins extends Target {
         getEngineArtifactsDirectory(buildInfo.targetArch, buildMode);
     final Directory commonDir = engineDir.parent.childDirectory('tizen-common');
 
+    final TizenManifest tizenManifest =
+        TizenManifest.parseFromXml(tizenProject.manifestFile);
+    final String profile = buildInfo.deviceProfile;
+    final String? apiVersion = tizenManifest.apiVersion;
+    final String nuiSuffix = supportsNui(profile, apiVersion) ? '_nui' : '';
+
     final File embedder =
-        engineDir.childFile('libflutter_tizen_${buildInfo.deviceProfile}.so');
+        engineDir.childFile('libflutter_tizen_$profile$nuiSuffix.so');
     inputs.add(embedder);
 
     final Directory clientWrapperDir =
@@ -98,10 +104,6 @@ class NativePlugins extends Target {
     final Directory publicDir = commonDir.childDirectory('public');
 
     assert(tizenSdk != null);
-    final TizenManifest tizenManifest =
-        TizenManifest.parseFromXml(tizenProject.manifestFile);
-    final String profile = buildInfo.deviceProfile;
-    final String? apiVersion = tizenManifest.apiVersion;
     final Rootstrap rootstrap = tizenSdk!.getFlutterRootstrap(
       profile: profile,
       apiVersion: apiVersion,
@@ -128,7 +130,7 @@ class NativePlugins extends Target {
         configuration: buildConfig,
         arch: getTizenCliArch(buildInfo.targetArch),
         predefines: <String>[
-          '${buildInfo.deviceProfile.toUpperCase()}_PROFILE',
+          '${profile.toUpperCase()}_PROFILE',
         ],
         extraOptions: <String>[
           if (!plugin.isSharedLib) '-fPIC',

--- a/lib/build_targets/utils.dart
+++ b/lib/build_targets/utils.dart
@@ -5,6 +5,7 @@
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 
@@ -45,4 +46,17 @@ String getLibNameForFileName(String name) {
     name = name.substring(0, name.lastIndexOf('.'));
   }
   return name;
+}
+
+/// Returns true if the platform identified by [profile] and [apiVersion]
+/// supports NUI.
+bool supportsNui(String profile, String? apiVersion) {
+  if (profile != 'mobile' && profile != 'tv') {
+    return false;
+  }
+  final Version? version = Version.parse(apiVersion);
+  if (version == null) {
+    return false;
+  }
+  return version >= Version(6, 5, 0);
 }


### PR DESCRIPTION
Tool side changes:
- Do not inject the `NUI_SUPPORT` macro value.
- Introduce a utility function `supportsNui`.
- Link a right embedder when building plugins.

Embedding (C#) changes:
- Exclude `NUIFlutterView.cs` from build when targeting Tizen 4.0.
- Code formatting (see https://github.com/flutter-tizen/flutter-tizen/pull/426) and cleaups.
- Remove unused `InitialWidth` and `InitialHeight`.
- Remove unnecessary `Debug.Assert` checks from `Width` and `Height` properties.

I just applied suggestions from my Visual Studio (IntelliSense). I recommend you to use Visual Studio (on a Windows machine) when working on any C# code.

I haven't tested the change (because I don't have NUI sample code) so please check if the code works.